### PR TITLE
Update boto3 to version 1.18.34

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.18.21" %}
-{% set hash = "00748c760dc30be61c6db4b092718f6a9f8d27c767da0e232695a65adb75cde8" %}
+{% set version = "1.18.34" %}
+{% set hash = "5116e9bdec19adcc5531a9b7b535be77d5314eef092aaf7033ace48a9be65036" %}
 
 {% set vmajor,vminor,vpatch = version.split('.') %}
 # ALWAYS DOUBLE-CHECK THESE OFFSETS AGAINST UPSTREAM setup.py
@@ -25,12 +25,12 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
     - wheel
     - setuptools
   run:
-    - python
+    - python >=3.6
     - botocore {{ botocore_bounds }}
     - jmespath >=0.7.1,<1.0.0
     - s3transfer >=0.5.0,<0.6.0


### PR DESCRIPTION
The pull request is still on progress

1. check the upstream

2. check the pinnings
https://github.com/boto/boto3/blob/1.18.34/tox.ini
https://github.com/boto/boto3/blob/1.18.34/setup.py
https://github.com/boto/boto3/blob/1.18.34/setup.cfg

3. check changelogs
https://github.com/boto/boto3/blob/1.18.34/CHANGELOG.rst

There were no breanking changes or deprecations mentioned in the changelog. 
Most of the changes were additions to the API

4. additional research
https://github.com/conda-forge/boto3-feedstock/issues

There are no open issues on condaforge at the time of the review

5. verify dev_url
6. verify doc_url

7. verify pip to the test section
9. verify the test section
10. additional tests

In order to test the `boto3` package version `1.18.34` the following test was used:
`conda build boto3-feedstock --test`
The results were the following:
`All tests passed`

In addition `celery` was used to test `boto3` version `1.18.34`.
The pinings in the `celery` meta.yaml were modified so that it made use of `boto3` version `1.18.34`.

In order to conduct the test the following command was used:  
`conda build celery-feedstock --test`
The test result was the following:
`All tests passed`
