### PR TITLE
boto3 1.20.24

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.18.34" %}
-{% set hash = "5116e9bdec19adcc5531a9b7b535be77d5314eef092aaf7033ace48a9be65036" %}
+{% set version = "1.20.24" %}
+{% set hash = "739705b28e6b2329ea3b481ba801d439c296aaf176f7850729147ba99bbf8a9a" %}
 
 {% set vmajor,vminor,vpatch = version.split('.') %}
 # ALWAYS DOUBLE-CHECK THESE OFFSETS AGAINST UPSTREAM setup.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - wheel
     - setuptools
@@ -45,6 +45,7 @@ test:
     - boto3.s3
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Update boto3 to 1.20.24

Changelog: https://github.com/boto/boto3/blob/1.20.24/CHANGELOG.rst
License: https://github.com/boto/boto3/blob/1.20.24/LICENSE
Upstream setup file: https://github.com/boto/boto3/blob/1.20.24/setup.py

Actions:
1. Fix python in host and test/requires