### PR TITLE
Update to v1.24.28

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.24.2" %}
-{% set hash = "927b5e8e2decad746e6c32bb81f15c2ea9ab4398286134d21f6742493eb893f6" %}
+{% set version = "1.24.28" %}
+{% set hash = "af12023bb8f3059bb72697bcf9be860c492760c8201ec09246bd0b04cea88573" %}
 
 {% set vmajor,vminor,vpatch = version.split('.') %}
 # ALWAYS DOUBLE-CHECK THESE OFFSETS AGAINST UPSTREAM setup.py


### PR DESCRIPTION
Changelog: https://github.com/boto/boto3/blob/1.24.28/CHANGELOG.rst
License: https://github.com/boto/boto3/blob/1.24.28/LICENSE
Upstream setup file: https://github.com/boto/boto3/blob/1.24.28/setup.py

Actions:
- Update version and hash.
- Confirmed key dependencies pinnings are up-to-date:
```
    'botocore>=1.27.28,<1.28.0',   # Also updating now in another PR
    'jmespath>=0.7.1,<2.0.0',
    's3transfer>=0.6.0,<0.7.0',
```