### PR TITLE
Update to 1.29.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr55/b228160

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr55/b228160

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "boto3" %}
-{% set version = "1.26.76" %}
+{% set version = "1.29.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 30c7d967ed1c6b5a05643e42cae9d4d36c3f1cb6782637ddc7007a104cfd9027
+  sha256: 20285ebf4e98b2905a88aeb162b4f77ff908b2e3e31038b3223e593789290aa3
 
 build:
   number: 0
@@ -22,9 +22,9 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.29.76,<1.30.0
+    - botocore >=1.32.1,<1.33.0
     - jmespath >=0.7.1,<2.0.0
-    - s3transfer >=0.6.0,<0.7.0
+    - s3transfer >=0.7.0,<0.8.0
 
 test:
   imports:
@@ -40,7 +40,7 @@ test:
     - pip check
 
 about:
-  home: https://aws.amazon.com/sdk-for-python
+  home: https://aws.amazon.com/sdk-for-python/
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache


### PR DESCRIPTION
Upstream: https://github.com/boto/boto3/tree/1.29.1

Depends on:
* https://github.com/AnacondaRecipes/botocore-feedstock/pull/55