### PR TITLE
update to 1.28.64

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_check: false
-
-channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr56/9892801

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+aggregate_check: false
+
+channels:
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr56/9892801

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "boto3" %}
-{% set version = "1.29.1" %}
+{% set version = "1.28.64" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 20285ebf4e98b2905a88aeb162b4f77ff908b2e3e31038b3223e593789290aa3
+  sha256: a5cf93b202568e9d378afdc84be55a6dedf11d30156289fe829e23e6d7dccabb
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.32.1,<1.33.0
+    - botocore >=1.31.64,<1.32.0
     - jmespath >=0.7.1,<2.0.0
     - s3transfer >=0.7.0,<0.8.0
 


### PR DESCRIPTION
Changes:
- 1.28.64 to align with botocore release

https://github.com/boto/boto3/tree/1.28.64