### PR TITLE
boto3 1.34.69

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f
+  - https://staging.continuum.io/prefect/fs/s3transfer-feedstock/pr7/670e06b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f
-  - https://staging.continuum.io/prefect/fs/s3transfer-feedstock/pr7/670e06b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "boto3" %}
-{% set version = "1.29.1" %}
+{% set version = "1.34.69" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 20285ebf4e98b2905a88aeb162b4f77ff908b2e3e31038b3223e593789290aa3
+  sha256: 898a5fed26b1351352703421d1a8b886ef2a74be6c97d5ecc92432ae01fda203
 
 build:
   number: 0
@@ -22,9 +22,9 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.32.1,<1.33.0
+    - botocore >=1.34.69,<1.35.0
     - jmespath >=0.7.1,<2.0.0
-    - s3transfer >=0.7.0,<0.8.0
+    - s3transfer >=0.10.0,<0.11.0
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4619](https://anaconda.atlassian.net/browse/PKG-4619)
- release-notes-tagged: https://github.com/boto/boto3/releases/tag/v1.34.69
- release-diff: https://github.com/boto/boto3/compare/1.29.1...1.34.69
- changelog: https://github.com/boto/boto3/blob/1.34.69/CHANGELOG.rst
- license: https://github.com/boto/boto3/blob/develop/LICENSE
- requirements-tagged:
  - https://github.com/boto/boto3/blob/1.34.69/setup.cfg
  - https://github.com/boto/boto3/blob/1.34.69/setup.py


### Explanation of changes:

- Update pinnings

### Notes:

- The build order of boto3 1.34.69 and downstream packages:
botocore 1.34.69 ->
-> boto3 1.34.69
-> aiobotocore 2.12.3 -> s3fs 2024.3.1
-> s3transfer 0.10.1

[PKG-4619]: https://anaconda.atlassian.net/browse/PKG-4619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ