### PR TITLE
boto 1.34.82

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr57/9b28a3f
   - https://staging.continuum.io/prefect/fs/s3transfer-feedstock/pr7/670e06b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f
+  - https://staging.continuum.io/prefect/fs/s3transfer-feedstock/pr7/670e06b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr57/9b28a3f
-  - https://staging.continuum.io/prefect/fs/s3transfer-feedstock/pr7/670e06b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "boto3" %}
-{% set version = "1.29.1" %}
+{% set version = "1.34.69" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 20285ebf4e98b2905a88aeb162b4f77ff908b2e3e31038b3223e593789290aa3
+  sha256: 898a5fed26b1351352703421d1a8b886ef2a74be6c97d5ecc92432ae01fda203
 
 build:
   number: 0
@@ -22,9 +22,9 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.32.1,<1.33.0
+    - botocore >=1.34.69,<1.35.0
     - jmespath >=0.7.1,<2.0.0
-    - s3transfer >=0.7.0,<0.8.0
+    - s3transfer >=0.10.0,<0.11.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "boto3" %}
-{% set version = "1.34.69" %}
+{% set version = "1.34.82" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 898a5fed26b1351352703421d1a8b886ef2a74be6c97d5ecc92432ae01fda203
+  sha256: fcdb84936b04d5f78c8c8667b65bf5b9803cf39fd25bb7fe57ba237074e36171
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.34.69,<1.35.0
+    - botocore >=1.34.82,<1.35.0
     - jmespath >=0.7.1,<2.0.0
     - s3transfer >=0.10.0,<0.11.0
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4503](https://anaconda.atlassian.net/browse/PKG-4503)
- release-notes-tagged: https://github.com/boto/boto3/releases/tag/v1.34.82
- release-diff: https://github.com/boto/boto3/compare/1.29.1...1.34.82
- changelog: https://github.com/boto/boto3/blob/1.34.82/CHANGELOG.rst
- license: https://github.com/boto/boto3/blob/develop/LICENSE
- requirements-tagged:
  - https://github.com/boto/boto3/blob/1.34.82/setup.cfg
  - https://github.com/boto/boto3/blob/1.34.82/setup.py


### Explanation of changes:

- Update pinnings

### Notes:

- The build order of boto3 1.34.82:
  botocore 1.34.82 -> boto3 1.34.82


[PKG-4503]: https://anaconda.atlassian.net/browse/PKG-4503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ