### PR TITLE
Boto3 Update 1.34.154

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "boto3" %}
-{% set version = "1.34.82" %}
+{% set version = "1.34.154" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fcdb84936b04d5f78c8c8667b65bf5b9803cf39fd25bb7fe57ba237074e36171
+  sha256: 864f06528c583dc7b02adf12db395ecfadbf9cb0da90e907e848ffb27128ce19
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - botocore >=1.34.82,<1.35.0
+    - botocore >=1.34.154,<1.35.0
     - jmespath >=0.7.1,<2.0.0
     - s3transfer >=0.10.0,<0.11.0
 


### PR DESCRIPTION
## ☆Boto3 1.34.154 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5463)
[Upstream](https://github.com/boto/boto3)
# Changes
- Updated version number and `sha256`
- Skip to `python` versions less than 3.8